### PR TITLE
Document verification commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,37 @@
 # Workbench
 
+## Build (local)
+
+Build the solution:
+
+```bash
+dotnet build Workbench.slnx
+```
+
+## Test
+
+Run the automated tests:
+
+```bash
+dotnet test tests/Workbench.Tests/Workbench.Tests.csproj
+```
+
+## Run (CLI)
+
+Run the CLI locally:
+
+```bash
+dotnet run --project src/Workbench/Workbench.csproj -- --help
+```
+
+## Verification
+
+Run the full test suite (matches CI expectations):
+
+```bash
+dotnet test Workbench.slnx
+```
+
 ## Build (AOT)
 
 Publish a single native binary:
@@ -9,3 +41,7 @@ dotnet publish src/Workbench/Workbench.csproj -c Release -r osx-arm64
 ```
 
 Replace the runtime identifier with your target (e.g., `win-x64`, `linux-x64`).
+
+## Command reference
+
+See the full CLI command list and options in `docs/30-contracts/cli-help.md`.

--- a/docs/00-overview/workbench-spec.md
+++ b/docs/00-overview/workbench-spec.md
@@ -510,6 +510,10 @@ Prefix: WB
 Test data:
 - /testdata/ small fixtures for markdown parsing and validation.
 
+How to run:
+- `dotnet test tests/Workbench.Tests/Workbench.Tests.csproj`
+- `dotnet test Workbench.slnx` (solution-wide)
+
 ---
 
 ## Packaging

--- a/docs/30-contracts/cli-help.md
+++ b/docs/30-contracts/cli-help.md
@@ -43,6 +43,7 @@ Commands:
 
 - `workbench doctor`
   - Check git, config, and expected paths.
+  - Includes `gh` availability/auth checks; unauthenticated `gh` reports a warning.
   - Example: `workbench doctor`
 
 - `workbench init [--force]`

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -88,6 +88,9 @@ Data:
 }
 ```
 
+Notes:
+- `gh` is `warn` when installed but not authenticated; run `gh auth login` to fix.
+
 ## workbench scaffold
 
 Data:


### PR DESCRIPTION
### Motivation
- Make it explicit how to run the full test suite locally so contributors can verify changes match CI expectations.
- Surface local `dotnet` build/test commands in top-level documentation for easier onboarding.
- Record the testing commands in the project spec so integration and unit test runners are discoverable.

### Description
- Added a `Verification` section to `README.md` with the full-suite command `dotnet test Workbench.slnx` and added local `Build`/`Test` instructions and a link to the CLI command reference.
- Added a `How to run` subsection to `docs/00-overview/workbench-spec.md` documenting `dotnet test tests/Workbench.Tests/Workbench.Tests.csproj` and `dotnet test Workbench.slnx`.
- Small editorial updates to make test/run commands prominent for contributors and to align local verification with CI.

### Testing
- No automated tests were executed as part of this change.
- Changes were validated via local edits and committed to the working tree without running `dotnet test` or CI.
- CI is expected to run `dotnet test Workbench.slnx` when triggered by repository workflows.
- No runtime verification or unit/integration test runs were performed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ea3f399e4832e81ac3fe8817cf881)