### PR TITLE
Add .NET tool packaging metadata and README pack instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ Build the solution:
 dotnet build Workbench.slnx
 ```
 
+## Pack (NuGet tool)
+
+Build the .NET tool package:
+
+```bash
+dotnet pack src/Workbench/Workbench.csproj -c Release
+```
+
 ## Test
 
 Run the automated tests:

--- a/src/Workbench/Workbench.csproj
+++ b/src/Workbench/Workbench.csproj
@@ -10,6 +10,11 @@
     <PublishTrimmed>true</PublishTrimmed>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>workbench</ToolCommandName>
+    <PackageId>Bravellian.Workbench</PackageId>
+    <Version>0.1.0</Version>
+    <PackageVersion>0.1.0</PackageVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Motivation
- Prepare the project to be distributed as a .NET global tool by adding packaging metadata to the project file. 
- Expose a stable CLI command name so consumers can invoke the tool as `workbench` once installed. 
- Provide a simple local packaging workflow in `README.md` to document how to create the NuGet package. 
- Leave version fields present so the package can be published or later wired to a versioning tool like GitVersion. 

### Description
- Added packaging properties to `src/Workbench/Workbench.csproj`, including `PackAsTool`, `ToolCommandName`, `PackageId`, `Version`, and `PackageVersion`. 
- Set the CLI command name to `workbench` via the `ToolCommandName` property. 
- Set `PackageId` to `Bravellian.Workbench` and populated `Version`/`PackageVersion` with `0.1.0`. 
- Updated `README.md` to document the `dotnet pack src/Workbench/Workbench.csproj -c Release` command for producing the tool package. 

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ef0a8b200832ead93ced53831d7d5)