### PR TITLE
Add documentation structure overview

### DIFF
--- a/docs/00-overview/documentation-structure.md
+++ b/docs/00-overview/documentation-structure.md
@@ -1,0 +1,87 @@
+# Documentation structure
+
+## Purpose
+This overview describes how the documentation is organized, who each category serves, and where new material should live. It aligns with the scaffold described in [Workbench spec](/docs/00-overview/workbench-spec.md) and clarifies the intent of each `/docs/*` directory.
+
+## Quick lookup: doc types and canonical paths
+
+| Doc type | Canonical path | Intended audience | Belongs here (examples) |
+| --- | --- | --- | --- |
+| Overview | `/docs/00-overview/` | Everyone | Vision, scope, and cross-cutting specs (e.g., [workbench-spec](/docs/00-overview/workbench-spec.md)). |
+| Product | `/docs/10-product/` | Product, design, engineering | Feature specs, requirements, user journeys (see [Product README](/docs/10-product/README.md)). |
+| Architecture | `/docs/20-architecture/` | Engineering | System design, data flow, component boundaries (see [Architecture README](/docs/20-architecture/README.md)). |
+| Contracts | `/docs/30-contracts/` | Engineering, integrators | Schemas, CLI/API contracts, interface docs (see [Contracts README](/docs/30-contracts/README.md)). |
+| Decisions | `/docs/40-decisions/` | Engineering, stakeholders | ADRs and tradeoff history (see [Decisions README](/docs/40-decisions/README.md)). |
+| Runbooks | `/docs/50-runbooks/` | Ops, support, on-call | Operational procedures, troubleshooting, releases (see [Runbooks README](/docs/50-runbooks/README.md)). |
+| Tracking | `/docs/60-tracking/` | Delivery, leadership | Milestones, progress notes, delivery status (see [Tracking README](/docs/60-tracking/README.md)). |
+
+## Directory intent and placement guidance
+
+### `/docs/00-overview`
+**Audience:** everyone (first stop for orientation)
+
+**Purpose:** High-level summaries, the documentation map, and foundational specs that describe how Workbench is intended to work. The canonical scaffold and workflow description live in [workbench-spec](/docs/00-overview/workbench-spec.md).
+
+**Belongs here:**
+- Product vision or scope overviews
+- Repository-level documentation maps (like this file)
+- Any cross-cutting spec that frames the rest of the docs
+
+### `/docs/10-product`
+**Audience:** product, design, engineering
+
+**Purpose:** User-facing requirements and feature-level behavior. The stub [Product README](/docs/10-product/README.md) anchors the category.
+
+**Belongs here:**
+- Feature specs and acceptance criteria
+- User flows or experience notes
+- Roadmap-level requirement statements
+
+### `/docs/20-architecture`
+**Audience:** engineering
+
+**Purpose:** System-level design, architecture diagrams, and component boundaries. See [Architecture README](/docs/20-architecture/README.md).
+
+**Belongs here:**
+- High-level system diagrams
+- Data flow descriptions
+- Component responsibilities and interfaces
+
+### `/docs/30-contracts`
+**Audience:** engineering, integrators
+
+**Purpose:** Interface definitions and machine-readable contracts. The [Contracts README](/docs/30-contracts/README.md) lists current schema artifacts.
+
+**Belongs here:**
+- JSON schemas (e.g., work item and config schema)
+- CLI help/contract docs
+- API/interface definitions
+
+### `/docs/40-decisions`
+**Audience:** engineering, stakeholders
+
+**Purpose:** The history of architectural decisions, tradeoffs, and rationale. See [Decisions README](/docs/40-decisions/README.md).
+
+**Belongs here:**
+- ADRs that capture options, tradeoffs, and chosen direction
+- Decision logs that explain why a path was selected
+
+### `/docs/50-runbooks`
+**Audience:** ops, support, on-call
+
+**Purpose:** Operational guidance and step-by-step procedures. See [Runbooks README](/docs/50-runbooks/README.md).
+
+**Belongs here:**
+- Troubleshooting guides
+- Release/checklist procedures
+- Operational playbooks
+
+### `/docs/60-tracking`
+**Audience:** delivery, leadership
+
+**Purpose:** Progress tracking, milestones, and delivery notes. See [Tracking README](/docs/60-tracking/README.md).
+
+**Belongs here:**
+- Milestone summaries
+- Status updates
+- Delivery retrospectives or timelines


### PR DESCRIPTION
### Motivation
- Provide a single, discoverable guide that maps the repository documentation layout and intended audiences.
- Align directory purposes with the existing `docs/00-overview/workbench-spec.md` scaffold to reduce ambiguity for contributors.
- Offer quick lookup and canonical paths to speed authoring and review of new documentation.
- Give concrete "belongs here" examples and link to README stubs so content placement stays consistent.

### Description
- Add `docs/00-overview/documentation-structure.md` which defines each top-level docs category, audience, and examples. 
- Include a quick lookup table of doc types and canonical paths for `/docs/00-overview`, `/docs/10-product`, `/docs/20-architecture`, `/docs/30-contracts`, `/docs/40-decisions`, `/docs/50-runbooks`, and `/docs/60-tracking`.
- Clarify directory intent and placement guidance with "belongs here" examples and links to the existing README stubs and `workbench-spec.md` for alignment.
- This is a docs-only addition with no changes to source code or runtime behavior.

### Testing
- No automated tests were added or executed for this documentation-only change.
- Change is documentation-only so no code paths or unit tests were affected.
- No CI jobs were intentionally run as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ef467e0dc832e912f0dd54a00c3fa)