### PR TITLE
Add documentation templates and require ADR/spec cross-links

### DIFF
--- a/docs/00-overview/workbench-spec.md
+++ b/docs/00-overview/workbench-spec.md
@@ -412,6 +412,10 @@ Examples:
 - Plain text: `TASK-0042`
 - Markdown link: `[TASK-0042](/work/items/TASK-0042-add-promotion-workflow.md)`
 
+Doc cross-link rules:
+- ADRs in `/docs/40-decisions` must include a "Related specs" section with at least one link to a spec in `/docs/10-product` or `/docs/20-architecture`.
+- Specs referenced in `related.specs` must include a backlink to the work item ID (plain text or markdown link).
+
 ### Errors (must fail)
 - Config file does not conform to workbench-config.schema.json (WB010)
 - Missing required front matter fields (per work-item.schema.json)
@@ -421,6 +425,8 @@ Examples:
 - related.specs/related.adrs references to missing files
 - related.files references to missing files
 - related.files targets missing a backlink to the work item ID
+- ADRs missing a related spec link in their "Related specs" section
+- Specs referenced in related.specs missing a backlink to the work item ID
 - Work item file not under configured items/done directories
 - Broken local markdown links in any repo markdown file
 

--- a/docs/10-product/README.md
+++ b/docs/10-product/README.md
@@ -1,3 +1,6 @@
 # Product
 
 Product requirements, feature specs, and user-facing behavior.
+
+Templates:
+- `docs/templates/feature-spec.md`

--- a/docs/30-contracts/README.md
+++ b/docs/30-contracts/README.md
@@ -2,6 +2,9 @@
 
 APIs, CLI interfaces, schemas, and external contracts.
 
+Templates:
+- `docs/templates/contract.md`
+
 Current schemas:
 - `docs/30-contracts/workbench-config.schema.json`
 - `docs/30-contracts/work-item.schema.json`

--- a/docs/40-decisions/README.md
+++ b/docs/40-decisions/README.md
@@ -1,3 +1,6 @@
 # Decisions
 
 Architecture Decision Records (ADRs) and tradeoff history.
+
+Templates:
+- `docs/templates/adr.md`

--- a/docs/50-runbooks/README.md
+++ b/docs/50-runbooks/README.md
@@ -1,3 +1,6 @@
 # Runbooks
 
 Operational procedures, troubleshooting, and release playbooks.
+
+Templates:
+- `docs/templates/runbook.md`

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -1,0 +1,10 @@
+# Document Templates
+
+Reusable templates for common documentation types. Copy these into the
+appropriate `docs/` subfolder and adapt them for the specific change.
+
+## Available templates
+- `feature-spec.md`: feature requirements and user-facing behavior.
+- `adr.md`: architecture decision records.
+- `runbook.md`: operational procedures and troubleshooting steps.
+- `contract.md`: API, schema, or interface contracts.

--- a/docs/templates/adr.md
+++ b/docs/templates/adr.md
@@ -1,0 +1,21 @@
+# ADR-0000: <title>
+
+- Status: proposed | accepted | superseded | deprecated
+- Date: YYYY-MM-DD
+- Owner: <name or team>
+
+## Context
+
+## Decision
+
+## Alternatives considered
+- 
+
+## Consequences
+- 
+
+## Related specs
+- </docs/10-product/feature-short-title.md>
+
+## Related work items
+- [TASK-0000](</work/items/TASK-0000-short-title.md>)

--- a/docs/templates/contract.md
+++ b/docs/templates/contract.md
@@ -1,0 +1,29 @@
+# Contract: <title>
+
+## Overview
+
+## Owner
+
+## Status
+- draft | active | deprecated
+
+## Consumers
+- 
+
+## Interface / schema
+- 
+
+## Examples
+```
+<example payload or CLI usage>
+```
+
+## Versioning and compatibility
+
+## Change management
+
+## Related specs
+- </docs/10-product/feature-short-title.md>
+
+## Related ADRs
+- </docs/40-decisions/ADR-0000-short-title.md>

--- a/docs/templates/feature-spec.md
+++ b/docs/templates/feature-spec.md
@@ -1,0 +1,32 @@
+# Feature Spec: <title>
+
+## Summary
+
+## Goals
+- 
+
+## Non-goals
+- 
+
+## User stories / scenarios
+- 
+
+## Requirements
+- 
+
+## UX notes
+
+## Dependencies
+- 
+
+## Risks and mitigations
+- 
+
+## Related work items
+- [TASK-0000](</work/items/TASK-0000-short-title.md>)
+
+## Related ADRs
+- </docs/40-decisions/ADR-0000-short-title.md>
+
+## Open questions
+- 

--- a/docs/templates/runbook.md
+++ b/docs/templates/runbook.md
@@ -1,0 +1,26 @@
+# Runbook: <title>
+
+## Purpose
+
+## Scope
+
+## Preconditions
+- 
+
+## Required access/tools
+- 
+
+## Procedure
+1. 
+
+## Validation
+- 
+
+## Rollback / recovery
+- 
+
+## Escalation / contacts
+- 
+
+## Related docs
+- 


### PR DESCRIPTION
### Motivation
- Provide reusable, consistent templates for common documentation types to speed and standardize authoring of specs, ADRs, runbooks, and contracts.
- Surface the templates from the relevant docs index pages so contributors can find and use them (`docs/10-product`, `docs/40-decisions`, `docs/50-runbooks`, `docs/30-contracts`).
- Strengthen validation rules so architectural decisions and specs remain discoverable and linked to work items.

### Description
- Add `docs/templates/` with `README.md` and templates: `feature-spec.md`, `adr.md`, `runbook.md`, and `contract.md`.
- Update `docs/10-product/README.md`, `docs/40-decisions/README.md`, `docs/50-runbooks/README.md`, and `docs/30-contracts/README.md` to reference the corresponding templates.
- Extend the validation rules in `docs/00-overview/workbench-spec.md` to require ADRs in `/docs/40-decisions` to include a `Related specs` section linking to a spec in `/docs/10-product` or `/docs/20-architecture`, and to require specs referenced in `related.specs` to include a backlink to the work item ID.

### Testing
- No automated tests were run because this is a documentation-only change.
- Changes were validated locally by updating the repo files and verifying the documentation updates are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694ef89c6494832e861f074a72e6f925)