### PR TITLE
Add Workbench front matter to docs

### DIFF
--- a/docs/00-overview/README.md
+++ b/docs/00-overview/README.md
@@ -1,3 +1,13 @@
+---
+workbench:
+  type: doc
+  workItems: []
+  codeRefs: []
+owner: platform
+status: active
+updated: 2025-12-27
+---
+
 # Overview
 
 High-level product summaries, vision, and specifications.

--- a/docs/00-overview/documentation-structure.md
+++ b/docs/00-overview/documentation-structure.md
@@ -1,3 +1,13 @@
+---
+workbench:
+  type: doc
+  workItems: []
+  codeRefs: []
+owner: platform
+status: active
+updated: 2025-12-27
+---
+
 # Documentation structure
 
 ## Purpose
@@ -114,6 +124,10 @@ Documentation can use optional YAML front matter aligned with work item conventi
 Example:
 ```md
 ---
+workbench:
+  type: doc
+  workItems: []
+  codeRefs: []
 owner: platform
 status: active
 updated: 2025-01-15

--- a/docs/00-overview/workbench-spec.md
+++ b/docs/00-overview/workbench-spec.md
@@ -1,3 +1,13 @@
+---
+workbench:
+  type: doc
+  workItems: []
+  codeRefs: []
+owner: platform
+status: active
+updated: 2025-12-27
+---
+
 # Bravellian Workbench - Specification (v0.1)
 
 ## Summary

--- a/docs/10-product/README.md
+++ b/docs/10-product/README.md
@@ -1,3 +1,13 @@
+---
+workbench:
+  type: doc
+  workItems: []
+  codeRefs: []
+owner: platform
+status: active
+updated: 2025-12-27
+---
+
 # Product
 
 Product requirements, feature specs, and user-facing behavior.

--- a/docs/20-architecture/README.md
+++ b/docs/20-architecture/README.md
@@ -1,3 +1,13 @@
+---
+workbench:
+  type: guide
+  workItems: []
+  codeRefs: []
+owner: platform
+status: active
+updated: 2025-12-27
+---
+
 # Architecture
 
 System architecture, data flows, and major components.

--- a/docs/30-contracts/README.md
+++ b/docs/30-contracts/README.md
@@ -1,3 +1,13 @@
+---
+workbench:
+  type: doc
+  workItems: []
+  codeRefs: []
+owner: platform
+status: active
+updated: 2025-12-27
+---
+
 # Contracts
 
 APIs, CLI interfaces, schemas, and external contracts.

--- a/docs/30-contracts/cli-help.md
+++ b/docs/30-contracts/cli-help.md
@@ -1,3 +1,13 @@
+---
+workbench:
+  type: doc
+  workItems: []
+  codeRefs: []
+owner: platform
+status: active
+updated: 2025-12-27
+---
+
 # Workbench CLI Help (v0.1)
 
 Usage:

--- a/docs/40-decisions/README.md
+++ b/docs/40-decisions/README.md
@@ -1,3 +1,13 @@
+---
+workbench:
+  type: doc
+  workItems: []
+  codeRefs: []
+owner: platform
+status: active
+updated: 2025-12-27
+---
+
 # Decisions
 
 Architecture Decision Records (ADRs) and tradeoff history.

--- a/docs/50-runbooks/README.md
+++ b/docs/50-runbooks/README.md
@@ -1,3 +1,13 @@
+---
+workbench:
+  type: doc
+  workItems: []
+  codeRefs: []
+owner: platform
+status: active
+updated: 2025-12-27
+---
+
 # Runbooks
 
 Operational procedures, troubleshooting, and release playbooks.

--- a/docs/60-tracking/README.md
+++ b/docs/60-tracking/README.md
@@ -1,3 +1,13 @@
+---
+workbench:
+  type: doc
+  workItems: []
+  codeRefs: []
+owner: platform
+status: active
+updated: 2025-12-27
+---
+
 # Tracking
 
 Milestones, progress tracking, and delivery notes.

--- a/docs/60-tracking/workbench-gaps.md
+++ b/docs/60-tracking/workbench-gaps.md
@@ -1,3 +1,13 @@
+---
+workbench:
+  type: doc
+  workItems: []
+  codeRefs: []
+owner: platform
+status: active
+updated: 2025-12-27
+---
+
 # Workbench Gaps And TODOs
 
 This file tracks missing features, gaps, and decisions to revisit.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,13 @@
+---
+workbench:
+  type: doc
+  workItems: []
+  codeRefs: []
+owner: platform
+status: active
+updated: 2025-12-27
+---
+
 # Docs
 
 Documentation for product, architecture, decisions, and operational guidance.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -1,3 +1,13 @@
+---
+workbench:
+  type: doc
+  workItems: []
+  codeRefs: []
+owner: platform
+status: active
+updated: 2025-12-27
+---
+
 # Command Output Contracts
 
 All JSON output follows a consistent envelope. Table output is human-readable and not specified here.

--- a/docs/templates/README.md
+++ b/docs/templates/README.md
@@ -1,3 +1,13 @@
+---
+workbench:
+  type: doc
+  workItems: []
+  codeRefs: []
+owner: <owner>
+status: template
+updated: 0000-00-00
+---
+
 # Document Templates
 
 Reusable templates for common documentation types. Copy these into the

--- a/docs/templates/adr.md
+++ b/docs/templates/adr.md
@@ -1,3 +1,13 @@
+---
+workbench:
+  type: adr
+  workItems: []
+  codeRefs: []
+owner: <owner>
+status: template
+updated: 0000-00-00
+---
+
 # ADR-0000: <title>
 
 - Status: proposed | accepted | superseded | deprecated

--- a/docs/templates/contract.md
+++ b/docs/templates/contract.md
@@ -1,3 +1,13 @@
+---
+workbench:
+  type: doc
+  workItems: []
+  codeRefs: []
+owner: <owner>
+status: template
+updated: 0000-00-00
+---
+
 # Contract: <title>
 
 ## Overview

--- a/docs/templates/feature-spec.md
+++ b/docs/templates/feature-spec.md
@@ -1,3 +1,13 @@
+---
+workbench:
+  type: spec
+  workItems: []
+  codeRefs: []
+owner: <owner>
+status: template
+updated: 0000-00-00
+---
+
 # Feature Spec: <title>
 
 ## Summary

--- a/docs/templates/runbook.md
+++ b/docs/templates/runbook.md
@@ -1,3 +1,13 @@
+---
+workbench:
+  type: runbook
+  workItems: []
+  codeRefs: []
+owner: <owner>
+status: template
+updated: 0000-00-00
+---
+
 # Runbook: <title>
 
 ## Purpose


### PR DESCRIPTION
### Motivation
- Ensure repository documentation is compatible with the Workbench tooling by adding the expected YAML front matter metadata.
- Make docs discoverable and linkable from work items by including the `workbench` section required by the tool.
- Provide consistent ownership, status, and `updated` metadata for documentation to support review and automation.
- Update the documentation example to show the canonical front matter format used by the tooling.

### Description
- Added YAML front matter to top-level docs and subfolder READMEs (e.g., `docs/README.md`, `docs/00-overview/*`, `docs/10-product/*`, `docs/20-architecture/*`, `docs/30-contracts/*`, `docs/40-decisions/*`, `docs/50-runbooks/*`, `docs/60-tracking/*`, and `docs/commands.md`) that includes a `workbench` object and `owner`, `status`, and `updated` keys.
- Updated all files in `docs/templates/` to include template front matter with `type`, empty `workItems`/`codeRefs`, `owner`, `status: template`, and `updated: 0000-00-00`.
- Amended the `docs/00-overview/documentation-structure.md` example to demonstrate the expected front matter block for docs.
- Changes were implemented as a docs-only update and preserve existing document bodies (front matter prepended).

### Testing
- No automated unit or integration tests were executed because this is a documentation-only change.
- Doc parsing/format expectations in source code (e.g., `FrontMatter.TryParse`, `DocService`) were referenced to ensure the front matter shape is compatible.
- Quick local verification was performed by adding front matter only to files that did not already contain it and ensuring files remain valid Markdown.
- No test failures were introduced by these documentation changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f5e423248832e9261d88af1b2d0f5)