### PR TITLE
Add AI-backed `workbench doc summarize` command to append change notes

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -39,6 +39,7 @@
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="10.16.1.129956" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
     <PackageVersion Include="Microsoft.CodeAnalysis.BannedApiAnalyzers" Version="4.14.0" />
+    <PackageVersion Include="Microsoft.Agents.AI.OpenAI" Version="1.0.0-preview.251219.1" />
     <PackageVersion Include="SimpleExec" Version="12.0.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.1" />
     <PackageVersion Include="YamlDotNet" Version="16.3.0" />

--- a/docs/30-contracts/cli-help.md
+++ b/docs/30-contracts/cli-help.md
@@ -128,6 +128,10 @@ Commands:
   - Sync doc/work item backlinks. `--all` adds Workbench front matter to all docs; `--dry-run` reports changes without writing.
   - Example: `workbench doc sync --all --dry-run`
 
+- `workbench doc summarize [--staged] [--path <path...>] [--dry-run] [--update-index]`
+  - Summarize markdown diffs using AI and append `workbench.changeNotes` entries.
+  - Example: `workbench doc summarize --staged --update-index`
+
 - `workbench spec new --title "<...>" [--path <...>] [--work-item <ID...>] [--code-ref <ref...>] [--force]`
   - Create a spec document and auto-link work items.
   - Example: `workbench spec new --title "Access model" --work-item TASK-0100`

--- a/docs/60-tracking/README.md
+++ b/docs/60-tracking/README.md
@@ -11,3 +11,6 @@ updated: 2025-12-27
 # Tracking
 
 Milestones, progress tracking, and delivery notes.
+
+Related:
+- [AI change notes for markdown docs](ai-change-notes.md)

--- a/docs/60-tracking/ai-change-notes.md
+++ b/docs/60-tracking/ai-change-notes.md
@@ -1,0 +1,52 @@
+---
+workbench:
+  type: doc
+  workItems: []
+  codeRefs: []
+  changeNotes: []
+owner: platform
+status: draft
+updated: 2025-12-27
+---
+
+# AI change notes for markdown docs
+
+Workbench can append AI-generated change notes to markdown documents so every
+doc keeps a lightweight history of updates. The `doc summarize` command
+calculates a git diff, asks an AI model to summarize it, and stores the note
+in `workbench.changeNotes` inside the document front matter.
+
+## Behavior
+
+- Only markdown files are considered.
+- Each summary is tagged with a short hash of the diff. If the same diff hash
+  is already present, no new entry is added.
+- When AI is not configured, the command reports a warning and exits without
+  changing files.
+
+## Configuration
+
+Set one of the following environment variables to enable AI summaries:
+
+- `WORKBENCH_AI_OPENAI_KEY` or `OPENAI_API_KEY`
+- `WORKBENCH_AI_MODEL` or `OPENAI_MODEL` (default: `gpt-4o-mini`)
+- `WORKBENCH_AI_PROVIDER` (`openai` or `none`; default: `openai`)
+
+Optional overrides:
+
+- `WORKBENCH_AI_SUMMARY_MAX_CHARS` (default: `240`)
+- `WORKBENCH_AI_SUMMARY_INSTRUCTIONS` (override the summary prompt)
+
+## Pre-commit hook example
+
+Add a pre-commit hook to keep summaries up to date:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+workbench doc summarize --staged --update-index
+```
+
+Save this as `.git/hooks/pre-commit` and make it executable (`chmod +x
+.git/hooks/pre-commit`).

--- a/src/Workbench/AiSummaryClient.cs
+++ b/src/Workbench/AiSummaryClient.cs
@@ -1,0 +1,82 @@
+using Microsoft.Agents.AI;
+using Microsoft.Extensions.AI;
+using OpenAI;
+using OpenAI.Chat;
+
+namespace Workbench;
+
+public sealed class AiSummaryClient
+{
+    private const int DefaultMaxSummaryChars = 240;
+    private readonly AIAgent agent;
+    private readonly int maxSummaryChars;
+
+    private AiSummaryClient(AIAgent agent, int maxSummaryChars)
+    {
+        this.agent = agent;
+        this.maxSummaryChars = maxSummaryChars;
+    }
+
+    public static bool TryCreate(out AiSummaryClient? client, out string? reason)
+    {
+        client = null;
+        reason = null;
+
+        var provider = Environment.GetEnvironmentVariable("WORKBENCH_AI_PROVIDER") ?? "openai";
+        if (string.Equals(provider, "none", StringComparison.OrdinalIgnoreCase))
+        {
+            reason = "WORKBENCH_AI_PROVIDER=none";
+            return false;
+        }
+        if (!string.Equals(provider, "openai", StringComparison.OrdinalIgnoreCase))
+        {
+            reason = $"Unsupported provider '{provider}'.";
+            return false;
+        }
+
+        var apiKey = Environment.GetEnvironmentVariable("WORKBENCH_AI_OPENAI_KEY")
+            ?? Environment.GetEnvironmentVariable("OPENAI_API_KEY");
+        if (string.IsNullOrWhiteSpace(apiKey))
+        {
+            reason = "Missing OPENAI_API_KEY or WORKBENCH_AI_OPENAI_KEY.";
+            return false;
+        }
+
+        var model = Environment.GetEnvironmentVariable("WORKBENCH_AI_MODEL")
+            ?? Environment.GetEnvironmentVariable("OPENAI_MODEL")
+            ?? "gpt-4o-mini";
+        var maxChars = DefaultMaxSummaryChars;
+        if (int.TryParse(Environment.GetEnvironmentVariable("WORKBENCH_AI_SUMMARY_MAX_CHARS"), out var parsed))
+        {
+            maxChars = Math.Clamp(parsed, 80, 600);
+        }
+
+        var instructions = Environment.GetEnvironmentVariable("WORKBENCH_AI_SUMMARY_INSTRUCTIONS")
+            ?? "You summarize markdown doc changes for change logs. Respond in 1-2 sentences, plain text only.";
+
+        AIAgent agent = new OpenAIClient(apiKey)
+            .GetChatClient(model)
+            .CreateAIAgent(instructions: instructions, name: "WorkbenchSummarizer");
+
+        client = new AiSummaryClient(agent, maxChars);
+        return true;
+    }
+
+    public async Task<string?> SummarizeAsync(string diffText)
+    {
+        var prompt = $"Summarize the following git diff for a markdown document. " +
+                     $"Return 1-2 sentences, no bullets, no markdown.\n\n{diffText}";
+        var summary = await agent.RunAsync(prompt);
+        if (string.IsNullOrWhiteSpace(summary))
+        {
+            return null;
+        }
+
+        var normalized = string.Join(' ', summary.Split(new[] { '\r', '\n' }, StringSplitOptions.RemoveEmptyEntries)).Trim();
+        if (normalized.Length > maxSummaryChars)
+        {
+            normalized = normalized[..maxSummaryChars].TrimEnd() + "…";
+        }
+        return normalized;
+    }
+}

--- a/src/Workbench/DocSummaryData.cs
+++ b/src/Workbench/DocSummaryData.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Workbench
+{
+    public sealed record DocSummaryData(
+        [property: JsonPropertyName("filesUpdated")] int FilesUpdated,
+        [property: JsonPropertyName("notesAdded")] int NotesAdded,
+        [property: JsonPropertyName("updatedFiles")] IList<string> UpdatedFiles,
+        [property: JsonPropertyName("skippedFiles")] IList<string> SkippedFiles,
+        [property: JsonPropertyName("errors")] IList<string> Errors,
+        [property: JsonPropertyName("warnings")] IList<string> Warnings);
+}

--- a/src/Workbench/DocSummaryOutput.cs
+++ b/src/Workbench/DocSummaryOutput.cs
@@ -1,0 +1,8 @@
+using System.Text.Json.Serialization;
+
+namespace Workbench
+{
+    public sealed record DocSummaryOutput(
+        [property: JsonPropertyName("ok")] bool Ok,
+        [property: JsonPropertyName("data")] DocSummaryData Data);
+}

--- a/src/Workbench/DocSummaryService.cs
+++ b/src/Workbench/DocSummaryService.cs
@@ -1,0 +1,220 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Collections;
+
+namespace Workbench;
+
+public sealed record DocSummaryResult(
+    int FilesUpdated,
+    int NotesAdded,
+    IList<string> UpdatedFiles,
+    IList<string> SkippedFiles,
+    IList<string> Errors,
+    IList<string> Warnings);
+
+public static class DocSummaryService
+{
+    private const int MaxDiffChars = 6000;
+
+    public static async Task<DocSummaryResult> SummarizeDocsAsync(
+        string repoRoot,
+        IEnumerable<string> paths,
+        bool staged,
+        bool dryRun,
+        bool updateIndex)
+    {
+        var updatedFiles = new List<string>();
+        var skippedFiles = new List<string>();
+        var errors = new List<string>();
+        var warnings = new List<string>();
+        var notesAdded = 0;
+
+        if (!AiSummaryClient.TryCreate(out var client, out var reason))
+        {
+            warnings.Add($"AI summaries disabled: {reason}");
+            return new DocSummaryResult(0, 0, updatedFiles, skippedFiles, errors, warnings);
+        }
+
+        foreach (var path in paths)
+        {
+            var normalized = path.Replace('\\', '/');
+            var fullPath = Path.IsPathRooted(path) ? path : Path.Combine(repoRoot, path);
+            if (!File.Exists(fullPath))
+            {
+                skippedFiles.Add($"{normalized} (missing)");
+                continue;
+            }
+            if (!fullPath.EndsWith(".md", StringComparison.OrdinalIgnoreCase))
+            {
+                skippedFiles.Add($"{normalized} (not markdown)");
+                continue;
+            }
+
+            var diff = staged
+                ? GitService.GetStagedDiff(repoRoot, path)
+                : GitService.GetWorkingDiff(repoRoot, path);
+            if (string.IsNullOrWhiteSpace(diff))
+            {
+                skippedFiles.Add($"{normalized} (no diff)");
+                continue;
+            }
+
+            var trimmedDiff = diff.Length > MaxDiffChars
+                ? diff[^MaxDiffChars..]
+                : diff;
+
+            var summary = await client!.SummarizeAsync(trimmedDiff);
+            if (string.IsNullOrWhiteSpace(summary))
+            {
+                warnings.Add($"{normalized} (AI returned empty summary)");
+                continue;
+            }
+
+            var diffHash = ComputeHash(diff);
+            if (!TryAppendSummary(fullPath, summary, diffHash, dryRun, out var added, out var result))
+            {
+                if (!string.IsNullOrWhiteSpace(result))
+                {
+                    warnings.Add($"{normalized} ({result})");
+                }
+                continue;
+            }
+
+            if (!added)
+            {
+                skippedFiles.Add($"{normalized} (summary already present)");
+                continue;
+            }
+
+            if (!dryRun)
+            {
+                notesAdded++;
+                updatedFiles.Add(normalized);
+                if (updateIndex)
+                {
+                    GitService.Add(repoRoot, path);
+                }
+            }
+            else
+            {
+                updatedFiles.Add($"{normalized} (dry run)");
+            }
+        }
+
+        return new DocSummaryResult(updatedFiles.Count, notesAdded, updatedFiles, skippedFiles, errors, warnings);
+    }
+
+    private static bool TryAppendSummary(
+        string path,
+        string summary,
+        string diffHash,
+        bool dryRun,
+        out bool added,
+        out string? error)
+    {
+        added = false;
+        error = null;
+        var content = File.ReadAllText(path);
+        if (!FrontMatter.TryParse(content, out var frontMatter, out var parseError))
+        {
+            error = $"front matter parse failed: {parseError}";
+            return false;
+        }
+
+        var workbench = EnsureWorkbench(frontMatter!, out var changed);
+        var notes = EnsureStringList(workbench, "changeNotes", out var notesChanged);
+        var shortHash = diffHash[..8];
+        if (notes.Any(note => ExtractHash(note) == shortHash))
+        {
+            return true;
+        }
+
+        notes.Add($"[{shortHash}] {DateTime.UtcNow:yyyy-MM-dd}: {summary}");
+        notesChanged = true;
+        added = true;
+
+        if ((changed || notesChanged) && !dryRun)
+        {
+            File.WriteAllText(path, frontMatter!.Serialize());
+        }
+        return true;
+    }
+
+    private static string ComputeHash(string diff)
+    {
+        var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(diff));
+        var builder = new StringBuilder(bytes.Length * 2);
+        foreach (var b in bytes)
+        {
+            builder.Append(b.ToString("x2"));
+        }
+        return builder.ToString();
+    }
+
+    private static string? ExtractHash(string note)
+    {
+        var trimmed = note.TrimStart();
+        if (!trimmed.StartsWith("[", StringComparison.Ordinal))
+        {
+            return null;
+        }
+        var endIndex = trimmed.IndexOf(']');
+        if (endIndex <= 1)
+        {
+            return null;
+        }
+        return trimmed[1..endIndex];
+    }
+
+    private static Dictionary<string, object?> EnsureWorkbench(FrontMatter frontMatter, out bool changed)
+    {
+        changed = false;
+        var workbench = new Dictionary<string, object?>(StringComparer.Ordinal);
+        var data = frontMatter.Data;
+        if (!data.TryGetValue("workbench", out var workbenchObj) || workbenchObj is null)
+        {
+            data["workbench"] = workbench;
+            changed = true;
+        }
+        else if (workbenchObj is Dictionary<string, object?> typed)
+        {
+            workbench = typed;
+        }
+        else if (workbenchObj is Dictionary<object, object> legacy)
+        {
+            workbench = legacy.ToDictionary(
+                kvp => kvp.Key.ToString() ?? string.Empty,
+                kvp => (object?)kvp.Value,
+                StringComparer.OrdinalIgnoreCase);
+            data["workbench"] = workbench;
+            changed = true;
+        }
+
+        return workbench;
+    }
+
+    private static List<string> EnsureStringList(Dictionary<string, object?> data, string key, out bool changed)
+    {
+        changed = false;
+        if (!data.TryGetValue(key, out var value) || value is null)
+        {
+            var list = new List<string>();
+            data[key] = list.Cast<object?>().ToList();
+            changed = true;
+            return list;
+        }
+        if (value is IEnumerable enumerable && value is not string)
+        {
+            var list = enumerable.Cast<object?>()
+                .Select(item => item?.ToString() ?? string.Empty)
+                .Where(item => item.Length > 0)
+                .ToList();
+            data[key] = list.Cast<object?>().ToList();
+            return list;
+        }
+        var reset = new List<string>();
+        data[key] = reset.Cast<object?>().ToList();
+        changed = true;
+        return reset;
+    }
+}

--- a/src/Workbench/GitService.cs
+++ b/src/Workbench/GitService.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Linq;
 
 namespace Workbench;
 
@@ -78,5 +79,39 @@ public static class GitService
         {
             throw new InvalidOperationException(result.StdErr.Length > 0 ? result.StdErr : "git push failed.");
         }
+    }
+
+    public static IList<string> GetStagedFiles(string repoRoot)
+    {
+        var result = Run(repoRoot, "diff", "--cached", "--name-only", "--diff-filter=ACMRT");
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(result.StdErr.Length > 0 ? result.StdErr : "git diff --cached failed.");
+        }
+        return result.StdOut
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(line => line.Trim())
+            .Where(line => line.Length > 0)
+            .ToList();
+    }
+
+    public static string GetStagedDiff(string repoRoot, string path)
+    {
+        var result = Run(repoRoot, "diff", "--cached", "--no-color", "--unified=0", "--", path);
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(result.StdErr.Length > 0 ? result.StdErr : "git diff --cached failed.");
+        }
+        return result.StdOut;
+    }
+
+    public static string GetWorkingDiff(string repoRoot, string path)
+    {
+        var result = Run(repoRoot, "diff", "--no-color", "--unified=0", "--", path);
+        if (result.ExitCode != 0)
+        {
+            throw new InvalidOperationException(result.StdErr.Length > 0 ? result.StdErr : "git diff failed.");
+        }
+        return result.StdOut;
     }
 }

--- a/src/Workbench/Workbench.csproj
+++ b/src/Workbench/Workbench.csproj
@@ -26,6 +26,7 @@
   <ItemGroup>
     <PackageReference Include="System.CommandLine" />
     <PackageReference Include="JsonSchema.Net" />
+    <PackageReference Include="Microsoft.Agents.AI.OpenAI" />
   </ItemGroup>
 
 </Project>

--- a/src/Workbench/WorkbenchJsonContext.cs
+++ b/src/Workbench/WorkbenchJsonContext.cs
@@ -23,6 +23,7 @@ namespace Workbench;
 [JsonSerializable(typeof(DocCreateOutput))]
 [JsonSerializable(typeof(DocSyncOutput))]
 [JsonSerializable(typeof(DocLinkOutput))]
+[JsonSerializable(typeof(DocSummaryOutput))]
 internal partial class WorkbenchJsonContext : JsonSerializerContext
 {
 }


### PR DESCRIPTION
### Motivation

- Provide an opt-in, idempotent way to capture concise summaries for markdown file changes so documentation keeps a lightweight change history. 
- Enable this as a pre-commit/CI-friendly workflow so summaries are added automatically when docs are modified. 
- Use Microsoft Agent Framework/OpenAI so the implementation can support multiple AI providers through a common API. 
- Keep behavior safe when no API key or provider is configured (command is a no-op with a warning). 

### Description

- Added an OpenAI Agent dependency and package reference via `Directory.Packages.props` and `src/Workbench/Workbench.csproj`. 
- Implemented `AiSummaryClient` to create an Agent Framework `AIAgent` backed by OpenAI and run summarization prompts. 
- Implemented `DocSummaryService` to compute diffs (`GetStagedDiff`/`GetWorkingDiff`), call the AI summarizer, and append idempotent `workbench.changeNotes` entries (short diff hash) into document front matter. 
- Added CLI plumbing in `Program.cs` for the `workbench doc summarize` command with options `--staged`, `--path`, `--dry-run`, and `--update-index`, plus JSON output types `DocSummaryData`/`DocSummaryOutput` and `WorkbenchJsonContext` entries, and documentation in `docs/60-tracking/ai-change-notes.md` and `docs/30-contracts/cli-help.md`. 

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694f6f5e9134832eb1a616202306749d)