### PR TITLE
Cap work item slug length at 80 chars

### DIFF
--- a/src/Workbench/WorkItemService.cs
+++ b/src/Workbench/WorkItemService.cs
@@ -5,6 +5,8 @@ namespace Workbench;
 
 public static class WorkItemService
 {
+    private const int MaxSlugLength = 80;
+
     public sealed record WorkItemResult(string Id, string Slug, string Path);
 
     public sealed record WorkItemListResult(IList<WorkItem> Items);
@@ -567,7 +569,14 @@ public static class WorkItemService
         var cleaned = Regex.Replace(lowered, @"[^a-z0-9-\s]", "", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
         var dashed = Regex.Replace(cleaned, @"\s+", "-", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
         var collapsed = Regex.Replace(dashed, @"-+", "-", RegexOptions.Compiled, TimeSpan.FromSeconds(1));
-        return collapsed.Trim('-');
+        var trimmed = collapsed.Trim('-');
+        if (trimmed.Length <= MaxSlugLength)
+        {
+            return trimmed;
+        }
+
+        var shortened = trimmed[..MaxSlugLength].Trim('-');
+        return shortened;
     }
 
     private static IEnumerable<string> EnumerateItems(string repoRoot, WorkbenchConfig config, bool includeDone)

--- a/tests/Workbench.Tests/SlugifyTests.cs
+++ b/tests/Workbench.Tests/SlugifyTests.cs
@@ -11,4 +11,12 @@ public class SlugifyTests
         var slug = WorkItemService.Slugify("Add promotion workflow!");
         Assert.AreEqual("add-promotion-workflow", slug);
     }
+
+    [TestMethod]
+    public void Slugify_TruncatesLongTitles()
+    {
+        var slug = WorkItemService.Slugify(new string('A', 120) + " trailing");
+        Assert.IsTrue(slug.Length <= 80);
+        Assert.IsFalse(slug.EndsWith("-", StringComparison.Ordinal));
+    }
 }


### PR DESCRIPTION
### Motivation

- Prevent extremely long generated work item filenames that can cause filesystem/path length errors during sync.  
- Ensure slugs remain human-readable and safe when derived from large or malformed issue titles.  
- Keep existing slug normalization behavior while bounding its length to avoid surprises.  

### Description

- Add `MaxSlugLength = 80` and update `Slugify` to truncate the normalized slug to this limit and trim trailing dashes.  
- Preserve the existing normalization steps (lowercasing, removing invalid chars, collapsing spaces/dashes) before truncation.  
- Add a unit test `Slugify_TruncatesLongTitles` to verify generated slugs are no longer than 80 characters and do not end with a dash.  

### Testing

- Added a unit test `Slugify_TruncatesLongTitles` in `tests/Workbench.Tests/SlugifyTests.cs` to cover truncation behavior.  
- Existing `Slugify_NormalizesTitle` test remains and still validates normalization behavior.  
- No automated test suite was executed as part of this change (tests were added but not run in this rollout).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695078a92018832e8f8f4ab5e0433ee4)