### PR TITLE
Only count file/index updates when writes occur (fix dry-run reporting)

### DIFF
--- a/src/Workbench/DocService.cs
+++ b/src/Workbench/DocService.cs
@@ -114,13 +114,10 @@ public static class DocService
                 }
             }
 
-            if (createdFrontMatter || docChanged || listChanged)
+            if ((createdFrontMatter || docChanged || listChanged) && !dryRun)
             {
-                if (!dryRun)
-                {
-                    File.WriteAllText(docPath, frontMatter!.Serialize());
-                    docsUpdated++;
-                }
+                File.WriteAllText(docPath, frontMatter!.Serialize());
+                docsUpdated++;
             }
         }
 
@@ -263,13 +260,10 @@ public static class DocService
                 listChanged = true;
             }
 
-            if (createdFrontMatter || docChanged || listChanged)
+            if ((createdFrontMatter || docChanged || listChanged) && !dryRun)
             {
-                if (!dryRun)
-                {
-                    File.WriteAllText(docPath, frontMatter!.Serialize());
-                    updated++;
-                }
+                File.WriteAllText(docPath, frontMatter!.Serialize());
+                updated++;
             }
         }
 

--- a/src/Workbench/DocService.cs
+++ b/src/Workbench/DocService.cs
@@ -119,8 +119,8 @@ public static class DocService
                 if (!dryRun)
                 {
                     File.WriteAllText(docPath, frontMatter!.Serialize());
+                    docsUpdated++;
                 }
-                docsUpdated++;
             }
         }
 
@@ -268,8 +268,8 @@ public static class DocService
                 if (!dryRun)
                 {
                     File.WriteAllText(docPath, frontMatter!.Serialize());
+                    updated++;
                 }
-                updated++;
             }
         }
 

--- a/src/Workbench/NavigationService.cs
+++ b/src/Workbench/NavigationService.cs
@@ -449,9 +449,9 @@ public static class NavigationService
 
         if (!dryRun)
         {
-            File.WriteAllText(filePath, updated ? newContent : fileContent);
+            File.WriteAllText(filePath, newContent);
         }
-        return 1;
+        return updated && !dryRun ? 1 : 0;
     }
 
     private static bool ReplaceSection(

--- a/src/Workbench/WorkItemService.cs
+++ b/src/Workbench/WorkItemService.cs
@@ -245,13 +245,10 @@ public static class WorkItemService
                 }
             }
 
-            if (changed)
+            if (changed && !dryRun)
             {
-                if (!dryRun)
-                {
-                    File.WriteAllText(item.Path, frontMatter.Serialize());
-                    updatedCount++;
-                }
+                File.WriteAllText(item.Path, frontMatter.Serialize());
+                updatedCount++;
             }
         }
 
@@ -285,13 +282,10 @@ public static class WorkItemService
             changed |= NormalizeList(related, "issues");
             changed |= NormalizeList(related, "branches");
 
-            if (changed)
+            if (changed && !dryRun)
             {
-                if (!dryRun)
-                {
-                    File.WriteAllText(item.Path, frontMatter.Serialize());
-                    updated++;
-                }
+                File.WriteAllText(item.Path, frontMatter.Serialize());
+                updated++;
             }
         }
 

--- a/src/Workbench/WorkItemService.cs
+++ b/src/Workbench/WorkItemService.cs
@@ -248,8 +248,8 @@ public static class WorkItemService
                 if (!dryRun)
                 {
                     File.WriteAllText(item.Path, frontMatter.Serialize());
+                    updatedCount++;
                 }
-                updatedCount++;
             }
         }
 
@@ -288,8 +288,8 @@ public static class WorkItemService
                 if (!dryRun)
                 {
                     File.WriteAllText(item.Path, frontMatter.Serialize());
+                    updated++;
                 }
-                updated++;
             }
         }
 


### PR DESCRIPTION
### Motivation
- Fix incorrect sync reporting where `nav sync`/`doc sync` and related commands reported index or file updates even when nothing was written or when running with `--dry-run`.
- Ensure counters for docs, work items, and index files reflect actual file writes to avoid misleading output.
- Prevent confusion when index sections or front-matter changes are claimed but no content (emoji/status/change-notes) appears in files.

### Description
- Update `NavigationService.UpdateIndexSection` to always write the computed section when applying and to return a positive update count only when content changed and `dryRun` is false.
- Modify `DocService.SyncLinks` to increment `docsUpdated` only after an actual write occurs (i.e., when not a dry run).
- Adjust `WorkItemService` so `SyncIssueLinks` and `NormalizeRelatedLinks` increment their update counters only when the file write executes, avoiding inflated counts during dry runs.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69507840d51c832e86b551a7e97df83d)