### PR TITLE
Fix GraphQL selection for issueOrPullRequest

### DIFF
--- a/src/Workbench/OctokitGithubProvider.cs
+++ b/src/Workbench/OctokitGithubProvider.cs
@@ -222,31 +222,64 @@ public sealed class OctokitGithubProvider : IGithubProvider
               repository(owner: $owner, name: $name) {
                 issueOrPullRequest(number: $number) {
                   __typename
-                  number
-                  title
-                  body
-                  url
-                  state
-                  labels(first: 100) { nodes { name } }
-                  timelineItems(first: 100, itemTypes: [CROSS_REFERENCED_EVENT, CONNECTED_EVENT, CLOSED_EVENT]) {
-                    nodes {
-                      __typename
-                      ... on CrossReferencedEvent {
-                        source {
-                          __typename
-                          ... on PullRequest { url }
+                  ... on Issue {
+                    number
+                    title
+                    body
+                    url
+                    state
+                    labels(first: 100) { nodes { name } }
+                    timelineItems(first: 100, itemTypes: [CROSS_REFERENCED_EVENT, CONNECTED_EVENT, CLOSED_EVENT]) {
+                      nodes {
+                        __typename
+                        ... on CrossReferencedEvent {
+                          source {
+                            __typename
+                            ... on PullRequest { url }
+                          }
+                        }
+                        ... on ConnectedEvent {
+                          subject {
+                            __typename
+                            ... on PullRequest { url }
+                          }
+                        }
+                        ... on ClosedEvent {
+                          closer {
+                            __typename
+                            ... on PullRequest { url }
+                          }
                         }
                       }
-                      ... on ConnectedEvent {
-                        subject {
-                          __typename
-                          ... on PullRequest { url }
+                    }
+                  }
+                  ... on PullRequest {
+                    number
+                    title
+                    body
+                    url
+                    state
+                    labels(first: 100) { nodes { name } }
+                    timelineItems(first: 100, itemTypes: [CROSS_REFERENCED_EVENT, CONNECTED_EVENT, CLOSED_EVENT]) {
+                      nodes {
+                        __typename
+                        ... on CrossReferencedEvent {
+                          source {
+                            __typename
+                            ... on PullRequest { url }
+                          }
                         }
-                      }
-                      ... on ClosedEvent {
-                        closer {
-                          __typename
-                          ... on PullRequest { url }
+                        ... on ConnectedEvent {
+                          subject {
+                            __typename
+                            ... on PullRequest { url }
+                          }
+                        }
+                        ... on ClosedEvent {
+                          closer {
+                            __typename
+                            ... on PullRequest { url }
+                          }
                         }
                       }
                     }


### PR DESCRIPTION
### Motivation
- A runtime GraphQL error occurred because selections were made directly on the `issueOrPullRequest` union, which is not allowed by GitHub's GraphQL API.
- The query needs to request fields separately for `Issue` and `PullRequest` to avoid union selection errors.
- The change preserves existing timeline parsing so linked pull requests are still discovered.

### Description
- Updated the GraphQL query in `ExecuteGraphqlAsync` to use inline fragments `... on Issue` and `... on PullRequest` instead of selecting fields directly on `issueOrPullRequest`.
- Duplicated the relevant field selections (including `number`, `title`, `body`, `url`, `state`, `labels` and `timelineItems`) under both fragments so both issues and PRs are handled.
- Modified file: `src/Workbench/OctokitGithubProvider.cs`.

### Testing
- No automated tests were run for this change.
- The patch was applied and committed locally without running the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6952e4ada61c832eba35661329121736)