### PR TITLE
Fix PowerShell interpolation in promote workflow

### DIFF
--- a/.github/workflows/workbench-promote.yml
+++ b/.github/workflows/workbench-promote.yml
@@ -82,7 +82,7 @@ jobs:
             $exitCode = $LASTEXITCODE
             if ($exitCode -ne 0) {
               Write-Host $commandOutput
-              throw "Command failed with exit code $exitCode: $FilePath $joinedArgs"
+              throw "Command failed with exit code ${exitCode}: $FilePath $joinedArgs"
             }
             return $output
           }


### PR DESCRIPTION
### Motivation
- The promote workflow was failing with a PowerShell variable parsing error (`Variable reference is not valid. ':' was not followed by a valid variable name character`).
- The error originates from the error message construction inside the `Invoke-Logged` function in `.github/workflows/workbench-promote.yml`.

### Description
- Change the throw message to use a disambiguated variable form by replacing `"$exitCode"` with `"${exitCode}"` in the `throw` statement.
- The modification is limited to the `Invoke-Logged` error handling in `.github/workflows/workbench-promote.yml` and does not affect other logic.

### Testing
- No automated tests were run because this is a workflow-only change.
- The change was committed and a PR was prepared successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69562efc6d18832eaf4d6b103c817422)