### PR TITLE
Ignore non-code paths in workflow triggers and add Workbench maintenance workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,21 @@ name: CI
 on:
   push:
     branches: ["**"]
+    paths-ignore:
+      - ".github/**"
+      - "docs/**"
+      - "assets/**"
+      - "examples/**"
+      - "testdata/**"
+      - "**/*.md"
   pull_request:
+    paths-ignore:
+      - ".github/**"
+      - "docs/**"
+      - "assets/**"
+      - "examples/**"
+      - "testdata/**"
+      - "**/*.md"
   workflow_dispatch:
     inputs:
       run_integration_tests:

--- a/.github/workflows/nuget-publish.yml
+++ b/.github/workflows/nuget-publish.yml
@@ -4,6 +4,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - ".github/**"
+      - "docs/**"
+      - "assets/**"
+      - "examples/**"
+      - "testdata/**"
+      - "**/*.md"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -2,6 +2,13 @@ name: Quality Gate
 
 on:
   pull_request:
+    paths-ignore:
+      - ".github/**"
+      - "docs/**"
+      - "assets/**"
+      - "examples/**"
+      - "testdata/**"
+      - "**/*.md"
   push:
     branches:
       - main
@@ -11,6 +18,13 @@ on:
       - user/**
       - users/**
       - hotfix/**
+    paths-ignore:
+      - ".github/**"
+      - "docs/**"
+      - "assets/**"
+      - "examples/**"
+      - "testdata/**"
+      - "**/*.md"
 
 jobs:
   verify:

--- a/.github/workflows/workbench-item-issue-sync.yml
+++ b/.github/workflows/workbench-item-issue-sync.yml
@@ -1,0 +1,63 @@
+name: Workbench Item Issue Sync
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 3 * * *"
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  item-issue-sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Install Workbench CLI tool
+        run: |
+          dotnet tool install --global Bravellian.Workbench
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+
+      - name: Configure GitHub provider
+        env:
+          GITHUB_TOKEN: ${{ secrets.WORKBENCH_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          WORKBENCH_GITHUB_TOKEN: ${{ secrets.WORKBENCH_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          workbench config set --path github.provider --value octokit
+
+      - name: Sync work items with GitHub issues
+        env:
+          GITHUB_TOKEN: ${{ secrets.WORKBENCH_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          WORKBENCH_GITHUB_TOKEN: ${{ secrets.WORKBENCH_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          workbench item sync --import-issues
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.WORKBENCH_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          commit-message: "Sync work items with GitHub issues"
+          branch: "chore/workbench-item-issue-sync"
+          title: "Sync work items with GitHub issues"
+          body: |
+            ## Summary
+            - Run `workbench item sync --import-issues`
+
+            ## Context
+            - Automated maintenance from the Workbench Item Issue Sync workflow.

--- a/.github/workflows/workbench-sync-normalize.yml
+++ b/.github/workflows/workbench-sync-normalize.yml
@@ -1,0 +1,65 @@
+name: Workbench Sync and Normalize
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 2 * * *"
+
+permissions:
+  contents: write
+  issues: write
+  pull-requests: write
+
+jobs:
+  sync-normalize:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: "10.0.x"
+
+      - name: Install Workbench CLI tool
+        run: |
+          dotnet tool install --global Bravellian.Workbench
+          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
+
+      - name: Configure GitHub provider
+        env:
+          GITHUB_TOKEN: ${{ secrets.WORKBENCH_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          WORKBENCH_GITHUB_TOKEN: ${{ secrets.WORKBENCH_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          workbench config set --path github.provider --value octokit
+
+      - name: Run sync and normalize
+        env:
+          GITHUB_TOKEN: ${{ secrets.WORKBENCH_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          WORKBENCH_GITHUB_TOKEN: ${{ secrets.WORKBENCH_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+        run: |
+          workbench sync
+          workbench normalize
+
+      - name: Create pull request
+        uses: peter-evans/create-pull-request@v6
+        with:
+          token: ${{ secrets.WORKBENCH_GITHUB_TOKEN || secrets.GITHUB_TOKEN }}
+          commit-message: "Sync and normalize workbench data"
+          branch: "chore/workbench-sync-normalize"
+          title: "Sync and normalize workbench data"
+          body: |
+            ## Summary
+            - Run `workbench sync`
+            - Run `workbench normalize`
+
+            ## Context
+            - Automated maintenance from the Workbench Sync and Normalize workflow.


### PR DESCRIPTION
### Motivation
- Prevent CI and publishing workflows from running on non-code changes such as docs, assets, or GitHub config updates.  
- Reduce wasted runner time and noise by ignoring edits under `.github/`, `docs/`, `assets/`, `examples/`, `testdata/`, and Markdown files.  
- Provide automated maintenance for Workbench data by adding workflows to sync work items with issues and to run `sync`/`normalize`.  
- Address feedback to ensure workflow triggers are scoped to relevant code changes.

### Description
- Added `paths-ignore` filters to `/.github/workflows/ci.yml` to ignore `.github/**`, `docs/**`, `assets/**`, `examples/**`, `testdata/**`, and `**/*.md` on both `push` and `pull_request` triggers.  
- Added the same `paths-ignore` filters to `/.github/workflows/quality.yml` and `/.github/workflows/nuget-publish.yml` for their `push`/`pull_request` triggers.  
- Added two new maintenance workflows `/.github/workflows/workbench-item-issue-sync.yml` and `/.github/workflows/workbench-sync-normalize.yml` that run on `workflow_dispatch` and a daily `cron`, configure the `github.provider`, install the `Bravellian.Workbench` tool, perform `workbench item sync --import-issues` or `workbench sync`/`workbench normalize`, and open PRs using `peter-evans/create-pull-request@v6`.  

### Testing
- No automated tests were run because these are workflow-only changes.  
- Changes to workflow YAML were linted visually and validated in the repository context.  
- Workflows will be exercised on the next relevant run in CI or via `workflow_dispatch`.  
- No CI or publish runs were expected to be triggered by these edits due to the added `paths-ignore` filters.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69563abbac04832e9d50269de55ff709)