### PR TITLE
Restrict voice edit updates to title and body

### DIFF
--- a/src/Workbench.Tui/TuiEntrypoint.cs
+++ b/src/Workbench.Tui/TuiEntrypoint.cs
@@ -1809,6 +1809,10 @@ public static partial class TuiEntrypoint
 
                 return $"""
                     Update the work item using the user's voice notes. Preserve anything not mentioned.
+                    The user update describes changes to apply, not text to copy verbatim. Do not include
+                    instructions like "update this task" unless the user explicitly wants that phrasing in
+                    the work item content. Only update the title and body sections (summary and acceptance
+                    criteria). Do not modify front matter fields, related links, or other metadata.
                     Existing work item:
                     Id: {item.Id}
                     Title: {item.Title}
@@ -2146,7 +2150,7 @@ public static partial class TuiEntrypoint
                         return;
                     }
 
-                    WorkItemService.ApplyDraft(item.Path, draft);
+                    WorkItemService.ApplyEditDraft(item.Path, draft);
                     ReloadItems();
                     ShowInfo($"{item.Id} updated.");
                 }


### PR DESCRIPTION
### Motivation
- Voice-driven edits were being treated as literal text and could introduce instruction-like phrasing into work items or alter front matter and related links.
- The intent is to ensure voice edits apply requested changes while preserving front matter, links, and other metadata.

### Description
- Add `ApplyEditDraft` in `src/Workbench.Core/WorkItemService.cs` that only updates the title and body sections (Summary and Acceptance criteria) and writes the front matter back without changing other metadata.
- Update `BuildWorkItemEditPrompt` in `src/Workbench.Tui/TuiEntrypoint.cs` to tell the model not to copy instruction text verbatim and to avoid modifying front matter, related links, or other metadata.
- Replace the TUI call from `WorkItemService.ApplyDraft` to `WorkItemService.ApplyEditDraft` so voice edits use the edit-only applicator.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957f39ab2c8832e971db9f95e09365b)