### PR TITLE
Prefer credentials.env over environment vars and add TUI credential status indicators

### DIFF
--- a/src/Workbench.Core/EnvLoader.cs
+++ b/src/Workbench.Core/EnvLoader.cs
@@ -20,11 +20,11 @@ public static class EnvLoader
             return;
         }
 
-        LoadEnvFile(Path.Combine(fullRoot, ".env"));
-        LoadEnvFile(Path.Combine(fullRoot, ".workbench", "credentials.env"));
+        LoadEnvFile(Path.Combine(fullRoot, ".env"), overrideExisting: false);
+        LoadEnvFile(Path.Combine(fullRoot, ".workbench", "credentials.env"), overrideExisting: true);
     }
 
-    private static void LoadEnvFile(string path)
+    private static void LoadEnvFile(string path, bool overrideExisting)
     {
         if (!File.Exists(path))
         {
@@ -67,10 +67,12 @@ public static class EnvLoader
                 }
             }
 
-            if (Environment.GetEnvironmentVariable(key) is null)
+            if (!overrideExisting && Environment.GetEnvironmentVariable(key) is not null)
             {
-                Environment.SetEnvironmentVariable(key, value);
+                continue;
             }
+
+            Environment.SetEnvironmentVariable(key, value);
         }
     }
 }

--- a/src/Workbench.Tui/TuiEntrypoint.Context.cs
+++ b/src/Workbench.Tui/TuiEntrypoint.Context.cs
@@ -102,8 +102,10 @@ public static partial class TuiEntrypoint
         public TextField? AiProviderField { get; set; }
         public Button? AiProviderPickButton { get; set; }
         public TextField? AiOpenAiKeyField { get; set; }
+        public Label? AiOpenAiKeyStatusLabel { get; set; }
         public TextField? AiModelField { get; set; }
         public TextField? GithubTokenField { get; set; }
+        public Label? GithubTokenStatusLabel { get; set; }
 
         public string[] WorkItemStatusOptions { get; }
         public string[] WorkItemTypeOptions { get; }

--- a/src/Workbench.Tui/TuiEntrypoint.UiHelpers.cs
+++ b/src/Workbench.Tui/TuiEntrypoint.UiHelpers.cs
@@ -97,6 +97,12 @@ public static partial class TuiEntrypoint
 
     private static string? GetEnvValue(IEnumerable<string> lines, string key)
     {
+        return TryGetEnvValue(lines, key, out var value) ? value : null;
+    }
+
+    private static bool TryGetEnvValue(IEnumerable<string> lines, string key, out string? value)
+    {
+        value = null;
         foreach (var line in lines)
         {
             if (!TryParseEnvLine(line, out var parsedKey, out var parsedValue))
@@ -105,11 +111,12 @@ public static partial class TuiEntrypoint
             }
             if (string.Equals(parsedKey, key, StringComparison.Ordinal))
             {
-                return parsedValue;
+                value = parsedValue;
+                return true;
             }
         }
 
-        return null;
+        return false;
     }
 
     private static void SetEnvValue(List<string> lines, string key, string? value)


### PR DESCRIPTION
### Motivation
- Repo-scoped credential files should override process environment variables so credentials stored in `.workbench/credentials.env` are honored. 
- The TUI Settings page needs to show whether OpenAI and GitHub credentials were found and where they came from. 
- Avoid showing default AI model values in the UI when a model is not explicitly set. 
- Ensure the process environment reflects saved credentials after the user updates them in the TUI.

### Description
- Update `EnvLoader.LoadRepoEnv` and `LoadEnvFile` to accept an `overrideExisting` flag and load `.env` without overriding existing env vars while loading `.workbench/credentials.env` with overrides. 
- Load repo envs from the TUI by calling `EnvLoader.LoadRepoEnv(repoRoot)` early in `TuiEntrypoint.RunAsync`. 
- Add status label fields to `TuiContext` and UI controls in `TuiEntrypoint` to display credential resolution status for `WORKBENCH_AI_OPENAI_KEY` and `WORKBENCH_GITHUB_TOKEN`. 
- Introduce `TryGetEnvValue` and `ResolveEnvValueFromSources` helpers to prefer `credentials.env` entries first, then fallback environment variables, and update the process environment via `ApplyCredentialEnvironment` after saving credentials. 

### Testing
- No automated tests were run because there is no test harness configured for these UI changes. 
- The repository contains no automated test commands to invoke for these changes. 
- Changes were limited to env loading behavior and TUI wiring to minimize risk to unrelated functionality. 
- Manual verification is expected for the TUI Settings page to confirm status labels and env precedence behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6957f45d04a0832e9aaf09bce682596b)