### PR TITLE
Repair Workbench sync links and mutation config

### DIFF
--- a/runbooks/maintainer-readiness.md
+++ b/runbooks/maintainer-readiness.md
@@ -33,7 +33,7 @@ Core boundaries:
   Workbench docs MCP server.
 - [`content`](../content): markdown source for the docs MCP server and the
   source tree published through [`docs.site.json`](../docs.site.json).
-- [`dist/mcp`](../dist/mcp): generated MCP manifests and bundled Worker output.
+- `dist/mcp`: generated MCP manifests and bundled Worker output.
 
 The CLI layer should stay thin. Put business rules in `Workbench.Core` and keep
 the generated command snapshot in [`specs/generated/commands.md`](../specs/generated/commands.md)
@@ -263,5 +263,5 @@ dotnet run --project src/Workbench/Workbench.csproj -- quality attest
   local tests do not prove remote repository settings.
 - The docs MCP Worker has a deploy script, but deployment requires Cloudflare
   configuration and secrets outside the local readiness pass.
-- Derived outputs under [`artifacts`](../artifacts), [`specs/generated`](../specs/generated),
-  and [`dist/mcp`](../dist/mcp) must not be edited by hand.
+- Derived outputs under `artifacts`, [`specs/generated`](../specs/generated),
+  and `dist/mcp` must not be edited by hand.

--- a/specs/verification/WB/VER-WB-0002-quality-evidence.md
+++ b/specs/verification/WB/VER-WB-0002-quality-evidence.md
@@ -56,8 +56,8 @@ The linked requirements are satisfied by the documented repository behavior and 
 ## Evidence
 
 - [`quality/testing-intent.yaml`](../../../quality/testing-intent.yaml)
-- [`artifacts/quality/testing/quality-summary.md`](../../../artifacts/quality/testing/quality-summary.md)
-- [`artifacts/quality/testing/quality-report.json`](../../../artifacts/quality/testing/quality-report.json)
+- `artifacts/quality/testing/quality-summary.md` (derived output)
+- `artifacts/quality/testing/quality-report.json` (derived output)
 - [`scripts/testing/verify-critical-coverage.ps1`](../../../scripts/testing/verify-critical-coverage.ps1)
 - [`tests/Workbench.Tests/QualityServiceTests.cs`](../../../tests/Workbench.Tests/QualityServiceTests.cs)
 - [`tests/Workbench.IntegrationTests/QualityCommandTests.cs`](../../../tests/Workbench.IntegrationTests/QualityCommandTests.cs)

--- a/specs/work-items/WB/WI-WB-0019-generate-quality-report-json-and-markdown-summary.md
+++ b/specs/work-items/WB/WI-WB-0019-generate-quality-report-json-and-markdown-summary.md
@@ -47,8 +47,8 @@ policy gate.
 
 ## Planned Changes
 
-- Workbench emits [`artifacts/quality/testing/quality-report.json`](../../../artifacts/quality/testing/quality-report.json) and
-  [`artifacts/quality/testing/quality-summary.md`](../../../artifacts/quality/testing/quality-summary.md).
+- Workbench emits `artifacts/quality/testing/quality-report.json` and
+  `artifacts/quality/testing/quality-summary.md` as derived outputs.
 - The report contains authored, observed, and assessment sections as separate
   structures.
 - Detectable gaps are explicit, structured, and grounded in current evidence.

--- a/stryker-config.json
+++ b/stryker-config.json
@@ -1,6 +1,6 @@
 {
   "stryker-config": {
-    "solution-path": "Workbench.slnx",
+    "solution": "Workbench.slnx",
     "project": "src/Workbench.Core/Workbench.Core.csproj",
     "test-projects": [
       "tests/Workbench.Tests/Workbench.Tests.csproj"


### PR DESCRIPTION
## What changed

- replace seven links to absent derived build outputs with non-link code references
- migrate Stryker's obsolete `solution-path` key to `solution`

## Root cause

Strict sync validation treated intentionally absent generated outputs as broken links, while Stryker 4.16 rejected its retired schema key before mutation testing.

## Validation

Targeted link checks, JSON/schema option validation, commit hooks, and `git diff --check` passed. The repository-wide validator is not usable from the parent multi-worktree layout because it scans sibling repositories.